### PR TITLE
(feat) Initial implementation of MongoDB for session storage.

### DIFF
--- a/Server/src/database.js
+++ b/Server/src/database.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var uri = process.env.DBURI || '127.0.0.1:27017/pathhero';
+var db = exports.db = require('monk')(uri);
+
+exports.db = db;
+exports.uri = uri;

--- a/Server/src/middleware.js
+++ b/Server/src/middleware.js
@@ -1,8 +1,17 @@
 'use strict';
 
 var express = require('express');
+var session = require('express-session');
+var MongoStore = require('connect-mongo')(session);
+var uri = require('./database').uri;
 
 module.exports = function(app) {
+  // Use sessions and store them in our MongoDB instance
+  app.use(session({
+    secret: '9u292grbervq3uh5v',
+    store: new MongoStore({url: 'mongodb://' + uri})
+  }));
+
   console.log('Serving Static Folder:', __dirname + '/../../Client/');
   app.use(express.static(__dirname + '/../../Client/'));
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "grunt-notify": "^0.4.1"
   },
   "dependencies": {
-    "express": "^4.12.3"
+    "connect-mongo": "^0.8.0",
+    "express": "^4.12.3",
+    "express-session": "^1.10.4",
+    "monk": "^1.0.1"
   }
 }


### PR DESCRIPTION
Please be sure to do an NPM install for this.

You will need to have a local MongoDB running for the server to work. For convenience any folder named db in the root of the project is already ignored so you can start this by running:

mongod --dbpath db

in a new shell.
